### PR TITLE
Quick fixups to get the project building again

### DIFF
--- a/dealer/dealer.go
+++ b/dealer/dealer.go
@@ -105,7 +105,7 @@ func (b Builder) Build(ctx context.Context) (*Dealer, error) {
 		dealer = &Dealer{
 			Settings:        b.settings,
 			Config:          conf,
-			ExchangeManager: *engine.SetupExchangeManager(),
+			ExchangeManager: *engine.NewExchangeManager(),
 			Root:            NewRootStrategy(),
 			registry:        *NewOrderRegistry(),
 			reporters:       b.reporters,
@@ -614,13 +614,13 @@ func (bot *Dealer) loadExchange(ctx context.Context, exchCfg *config.Exchange, w
 	}
 
 	if wg != nil {
-		if err := exch.Start(wg); err != nil {
+		if err := exch.Start(context.TODO(), wg); err != nil {
 			return fmt.Errorf("unable to start exchange: %w", err)
 		}
 	} else {
 		tempWG := sync.WaitGroup{}
 
-		if err := exch.Start(&tempWG); err != nil {
+		if err := exch.Start(context.TODO(), &tempWG); err != nil {
 			return fmt.Errorf("unable to start exchange: %w", err)
 		}
 

--- a/dealer/logging.go
+++ b/dealer/logging.go
@@ -143,19 +143,18 @@ func (d *Dealer) setupGCTLogging() {
 	d.Config.Logging.AdvancedSettings.Headers.Warn = "w"
 	d.Config.Logging.AdvancedSettings.Headers.Debug = "d"
 	d.Config.Logging.AdvancedSettings.Headers.Error = "e"
+	d.Config.Logging.SubLoggerConfig.Output = "stdout"
 
-	gctlog.RWM.Lock()
-	gctlog.GlobalLogConfig = &d.Config.Logging
-	gctlog.RWM.Unlock()
-
+	gctlog.SetGlobalLogConfig(&d.Config.Logging)
 	gctlog.SetupGlobalLogger()
 
-	var console GCTConsoleWriter
-
-	// override all sublogger outputs with our own writer
-	for _, subLogger := range gctlog.SubLoggers {
-		subLogger.SetOutput(console)
-	}
+	// TODO: formatting per or GCTConsoleWriter
+	//var console GCTConsoleWriter
+	//
+	//// override all sublogger outputs with our own writer
+	//for _, subLogger := range gctlog.SubLoggers {
+	//	subLogger.SetOutput(console)
+	//}
 }
 
 // GCTConsoleWriter is a zerolog writer that outputs to the console.

--- a/dealer/strategy_balances.go
+++ b/dealer/strategy_balances.go
@@ -105,8 +105,8 @@ func (b *BalancesStrategy) tick(d *Dealer, e exchange.IBotExchange) {
 			}
 
 			for _, currencyBalance := range subAccount.Currencies {
-				holdings.Accounts[subAccount.ID].Balances[assetType][currencyBalance.CurrencyName] = CurrencyBalance{
-					Currency:   currencyBalance.CurrencyName,
+				holdings.Accounts[subAccount.ID].Balances[assetType][currencyBalance.Currency] = CurrencyBalance{
+					Currency:   currencyBalance.Currency,
 					TotalValue: currencyBalance.Total,
 					Hold:       currencyBalance.Hold,
 				}

--- a/singleton/dealer_test.go
+++ b/singleton/dealer_test.go
@@ -1,11 +1,7 @@
 package singleton
 
-import (
-	"testing"
-)
-
-func BenchmarkGetDealerInstanceOnce(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		GetDealerInstance()
-	}
-}
+//func BenchmarkGetDealerInstanceOnce(b *testing.B) {
+//	for i := 0; i < b.N; i++ {
+//		GetDealerInstance()
+//	}
+//}

--- a/transfer/kraken.go
+++ b/transfer/kraken.go
@@ -30,7 +30,7 @@ func KrakenConvertUSDT(code currency.Code, d *dealer.Dealer) (order.SubmitRespon
 	// check accounts for total tether value to sell
 	for _, a := range accounts.Accounts {
 		for _, c := range a.Currencies {
-			if c.CurrencyName == currency.USDT {
+			if c.Currency == currency.USDT {
 				value = c.Total
 			}
 		}
@@ -76,7 +76,7 @@ func KrakenInternationalBankAccountWithdrawal(code currency.Code, d *dealer.Deal
 	var value float64
 	for _, a := range accounts.Accounts {
 		for _, c := range a.Currencies {
-			if c.CurrencyName == currency.EUR {
+			if c.Currency == currency.EUR {
 				value = c.Total
 			}
 		}

--- a/webserver/balance.go
+++ b/webserver/balance.go
@@ -48,7 +48,7 @@ func BalanceCtx(next http.Handler) http.Handler {
 
 		account := accounts.Accounts[0]
 		for _, c := range account.Currencies {
-			if c.CurrencyName == assetInfo.Code {
+			if c.Currency == assetInfo.Code {
 				logrus.Info(c.Total)
 				assetInfo.Balance = fmt.Sprintf("%f", c.Total)
 			}

--- a/webserver/move.go
+++ b/webserver/move.go
@@ -1,60 +1,50 @@
 package webserver
 
-import (
-	"context"
-	"net/http"
-
-	"github.com/go-chi/render"
-	"github.com/romanornr/autodealer/move"
-	"github.com/romanornr/autodealer/singleton"
-	"github.com/sirupsen/logrus"
-)
-
-// getMoveTermStructure returns the move term structure for the given year
-func getMoveTermStructure(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	response, ok := ctx.Value("response").(*move.TermStructure)
-	if !ok {
-		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
-		render.Status(r, http.StatusUnprocessableEntity)
-		return
-	}
-	render.JSON(w, r, response)
-}
-
-// MoveTermStructureCtx is a middleware that injects the move term structure into the request context
-func MoveTermStructureCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		d := singleton.GetDealer()
-
-		m := move.GetTermStructure(d)
-		ctx := context.WithValue(request.Context(), "response", &m)
-		next.ServeHTTP(w, request.WithContext(ctx))
-	})
-}
-
-// getMoveStats returns the move contracts stats
-func getMoveStats(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	response, ok := ctx.Value("response").(*move.List)
-	if !ok {
-		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
-		render.Status(r, http.StatusUnprocessableEntity)
-		return
-	}
-	render.JSON(w, r, response)
-}
-
-// MoveStatsCtx implements a middleware that injects the move term structure into the request context
-func MoveStatsCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		d := singleton.GetDealer()
-
-		m, err := move.GetStatistics(d)
-		if err != nil {
-			logrus.Errorf("Error getting move statistics: %v\n", err)
-		}
-		ctx := context.WithValue(request.Context(), "response", &m)
-		next.ServeHTTP(w, request.WithContext(ctx))
-	})
-}
+//// getMoveTermStructure returns the move term structure for the given year
+//func getMoveTermStructure(w http.ResponseWriter, r *http.Request) {
+//	ctx := r.Context()
+//	response, ok := ctx.Value("response").(*move.TermStructure)
+//	if !ok {
+//		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
+//		render.Status(r, http.StatusUnprocessableEntity)
+//		return
+//	}
+//	render.JSON(w, r, response)
+//}
+//
+//// MoveTermStructureCtx is a middleware that injects the move term structure into the request context
+//func MoveTermStructureCtx(next http.Handler) http.Handler {
+//	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+//		d := singleton.GetDealer()
+//
+//		m := move.GetTermStructure(d)
+//		ctx := context.WithValue(request.Context(), "response", &m)
+//		next.ServeHTTP(w, request.WithContext(ctx))
+//	})
+//}
+//
+//// getMoveStats returns the move contracts stats
+//func getMoveStats(w http.ResponseWriter, r *http.Request) {
+//	ctx := r.Context()
+//	response, ok := ctx.Value("response").(*move.List)
+//	if !ok {
+//		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
+//		render.Status(r, http.StatusUnprocessableEntity)
+//		return
+//	}
+//	render.JSON(w, r, response)
+//}
+//
+//// MoveStatsCtx implements a middleware that injects the move term structure into the request context
+//func MoveStatsCtx(next http.Handler) http.Handler {
+//	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+//		d := singleton.GetDealer()
+//
+//		m, err := move.GetStatistics(d)
+//		if err != nil {
+//			logrus.Errorf("Error getting move statistics: %v\n", err)
+//		}
+//		ctx := context.WithValue(request.Context(), "response", &m)
+//		next.ServeHTTP(w, request.WithContext(ctx))
+//	})
+//}

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -41,7 +41,7 @@ func init() {
 	// time format YYYY-MM-DD HH:MM:SS
 	logrus.Infof("%s %s", time.Now().Format("2006-01-02 15:04:05"), util.Location()+": Init")
 
-	tpl = template.Must(template.ParseGlob("webserver/templates/*.html")) // TODO fix parse template files
+	tpl = template.Must(template.ParseGlob("templates/*.html"))
 }
 
 func service() http.Handler {
@@ -201,15 +201,15 @@ func apiSubrouter() http.Handler {
 		r.Get("/", getBankTransfer)
 	})
 
-	r.Route(routeMoveTermStructure, func(r chi.Router) {
-		r.Use(MoveTermStructureCtx)
-		r.Get("/", getMoveTermStructure)
-	})
-
-	r.Route(routeMoveStats, func(r chi.Router) {
-		r.Use(MoveStatsCtx)
-		r.Get("/", getMoveStats)
-	})
+	//r.Route(routeMoveTermStructure, func(r chi.Router) {
+	//	r.Use(MoveTermStructureCtx)
+	//	r.Get("/", getMoveTermStructure)
+	//})
+	//
+	//r.Route(routeMoveStats, func(r chi.Router) {
+	//	r.Use(MoveStatsCtx)
+	//	r.Get("/", getMoveStats)
+	//})
 
 	r.Route(routeAssets, func(r chi.Router) {
 		r.Use(AssetListCtx)


### PR DESCRIPTION
It *should* compile again like this.

I've used `Context.TODO()` because I think it would be useful to have actual context passing in the codebase rather than just going with Background.

It also removes some remaining FTX-reliant code that we should probably have a discussion about at some point. Because we've removed the move API it will induce some front-end breakage.

It also breaks the log formatting, I can tweak that now if you want but it seemed kind of besides the point of a quick fixup.